### PR TITLE
Fix route order for biblioteca libros

### DIFF
--- a/js/backend/routes/bibliotecas.js
+++ b/js/backend/routes/bibliotecas.js
@@ -13,10 +13,10 @@ const {
 router.get('/', obtenerBibliotecas);
 
 // Rutas CRUD y la nueva ruta para libros de una biblioteca
+router.get('/:id/libros', obtenerLibrosPorBiblioteca);
 router.get('/:id', obtenerBibliotecaPorId);
 router.post('/', crearBiblioteca);
 router.put('/:id', actualizarBiblioteca);
 router.delete('/:id', eliminarBiblioteca);
-router.get('/:id/libros', obtenerLibrosPorBiblioteca);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- adjust `/api/bibliotecas` routes order so `/bibliotecas/:id/libros` is matched before `/:id`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -s http://localhost:5500/api/bibliotecas/1/libros` *(returns internal error due to missing DB credentials, confirming route matched)*

------
https://chatgpt.com/codex/tasks/task_e_68474ce410888331b305c3d3f21eaef8