### PR TITLE
Fix admin dashboard data loading

### DIFF
--- a/js/admin/modules/dashboard.js
+++ b/js/admin/modules/dashboard.js
@@ -25,6 +25,26 @@ export default async function initDashboard() {
         </tr>
       `).join('');
     }
+
+    // Cargar actividad reciente
+    try {
+      const actRes = await fetch('/api/dashboard/actividad');
+      const actividad = await actRes.json();
+      if (Array.isArray(actividad)) {
+        const list = document.getElementById('actividadReciente');
+        list.innerHTML = actividad.map(a => `
+          <li class="list-group-item d-flex justify-content-between align-items-center px-4 py-3">
+            <div>
+              <p class="mb-0"><strong>${a.accion}</strong></p>
+              <small class="text-muted">${a.usuario} - ${a.libro} (${a.biblioteca})</small>
+            </div>
+            <small class="text-muted">${new Date(a.fecha).toLocaleDateString()}</small>
+          </li>
+        `).join('');
+      }
+    } catch(e) {
+      console.error('Error cargando actividad:', e);
+    }
   } catch (err) {
     console.error('Error cargando dashboard:', err);
   }

--- a/js/backend/controllers/dashboardController.js
+++ b/js/backend/controllers/dashboardController.js
@@ -38,4 +38,33 @@ async function obtenerResumen(req, res) {
   }
 }
 
-module.exports = { obtenerResumen };
+// Devuelve una lista simple de actividad reciente basada en la tabla de préstam
+// os. Esta función es solo un ejemplo para poblar la sección "Actividad Reciente"
+// del dashboard.
+async function obtenerActividadReciente(req, res) {
+  try {
+    const result = await pool.query(`
+      SELECT p.id,
+             u.nombre AS usuario,
+             l.titulo AS libro,
+             b.nombre AS biblioteca,
+             COALESCE(p.fecha_devolucion, p.fecha_prestamo) AS fecha,
+             CASE WHEN p.fecha_devolucion IS NULL
+                  THEN 'Préstamo realizado'
+                  ELSE 'Préstamo devuelto'
+             END AS accion
+        FROM prestamos p
+        JOIN usuarios u ON p.usuario_id = u.id
+        JOIN biblioteca_libros bl ON p.biblioteca_libro_id = bl.id
+        JOIN libros l ON bl.libro_id = l.id
+        JOIN bibliotecas b ON bl.biblioteca_id = b.id
+       ORDER BY fecha DESC
+       LIMIT 5`);
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Error al obtener actividad reciente:', err);
+    res.status(500).json({ error: 'Error interno' });
+  }
+}
+
+module.exports = { obtenerResumen, obtenerActividadReciente };

--- a/js/backend/routes/dashboard.js
+++ b/js/backend/routes/dashboard.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
-const { obtenerResumen } = require('../controllers/dashboardController');
+const { obtenerResumen, obtenerActividadReciente } = require('../controllers/dashboardController');
 
 router.get('/', obtenerResumen);
+router.get('/actividad', obtenerActividadReciente);
 
 module.exports = router;

--- a/pages/admin/index.html
+++ b/pages/admin/index.html
@@ -291,42 +291,8 @@
                                 <h5 class="mb-0">Actividad Reciente</h5>
                             </div>
                             <div class="card-body p-0">
-                                <ul class="list-group list-group-flush">
-                                    <li class="list-group-item d-flex justify-content-between align-items-center px-4 py-3">
-                                        <div>
-                                            <p class="mb-0"><strong>Nuevo libro registrado</strong></p>
-                                            <small class="text-muted">Se agregó "Matemáticas Avanzadas"</small>
-                                        </div>
-                                        <small class="text-muted">Hace 2 horas</small>
-                                    </li>
-                                    <li class="list-group-item d-flex justify-content-between align-items-center px-4 py-3">
-                                        <div>
-                                            <p class="mb-0"><strong>Usuario registrado</strong></p>
-                                            <small class="text-muted">Nuevo usuario: Laura Díaz</small>
-                                        </div>
-                                        <small class="text-muted">Hace 5 horas</small>
-                                    </li>
-                                    <li class="list-group-item d-flex justify-content-between align-items-center px-4 py-3">
-                                        <div>
-                                            <p class="mb-0"><strong>Préstamo devuelto</strong></p>
-                                            <small class="text-muted">Carlos devolvió "La Ilíada"</small>
-                                        </div>
-                                        <small class="text-muted">Ayer</small>
-                                    </li>
-                                    <li class="list-group-item d-flex justify-content-between align-items-center px-4 py-3">
-                                        <div>
-                                            <p class="mb-0"><strong>Nueva biblioteca registrada</strong></p>
-                                            <small class="text-muted">Biblioteca Científica registrada</small>
-                                        </div>
-                                        <small class="text-muted">Hace 2 días</small>
-                                    </li>
-                                    <li class="list-group-item d-flex justify-content-between align-items-center px-4 py-3">
-                                        <div>
-                                            <p class="mb-0"><strong>Actualización de libro</strong></p>
-                                            <small class="text-muted">Se actualizaron ejemplares de "Don Quijote"</small>
-                                        </div>
-                                        <small class="text-muted">Hace 3 días</small>
-                                    </li>
+                                <ul id="actividadReciente" class="list-group list-group-flush">
+                                    <li class="list-group-item text-center py-3">Cargando...</li>
                                 </ul>
                             </div>
                             <div class="card-footer bg-white text-center">


### PR DESCRIPTION
## Summary
- add route and controller to get recent activity
- fetch recent activity in the dashboard module
- remove static items from dashboard HTML

## Testing
- `npm test`
- `curl -s http://localhost:5500/api/dashboard | jq`
- `curl -s http://localhost:5500/api/dashboard/actividad | jq`


------
https://chatgpt.com/codex/tasks/task_e_68475845a61c83318bb883331f918b91